### PR TITLE
Dockerize all microservices and harden startup behavior

### DIFF
--- a/docker-compose.debug.yml
+++ b/docker-compose.debug.yml
@@ -1,21 +1,69 @@
+x-debug-common: &debug-common
+  build:
+    context: .
+    dockerfile: ./Dockerfile
+    target: dev
+  env_file:
+    - .env
+  environment:
+    PYTHONPATH: /app
+    YOUTUBE_ENABLED: ${YOUTUBE_ENABLED:-false}
+    POLL_INTERVAL_SECONDS: ${POLL_INTERVAL_SECONDS:-30}
+  volumes:
+    - .:/app:rw
+  restart: unless-stopped
+
 services:
-  unified_container:
-    build:
-      context: .
-      dockerfile: ./Dockerfile
-      target: dev
-    image: unified_container_debug
-    container_name: unified_container_debug
-    command: ["tail", "-f", "/dev/null"]
+  api:
+    <<: *debug-common
+    image: echobot-debug
+    container_name: echobot-api-debug
+    command: ["python", "-m", "services.api.src.main", "--host", "0.0.0.0", "--port", "8000", "--reload"]
     ports:
       - "8000:8000"
+
+  chat_youtube:
+    <<: *debug-common
+    image: echobot-debug
+    container_name: echobot-chat-youtube-debug
+    command: ["python", "-m", "services.chat_youtube_service.src.main", "--host", "0.0.0.0", "--port", "8001", "--reload"]
+    ports:
       - "8001:8001"
+    depends_on:
+      - api
+
+  event_notifier:
+    <<: *debug-common
+    image: echobot-debug
+    container_name: echobot-event-notifier-debug
+    command: ["python", "-m", "services.event_notifier_service.src.main", "--host", "0.0.0.0", "--port", "8002", "--reload"]
+    ports:
       - "8002:8002"
-      - "8003:8003"
-      - "8004:8004"
-    volumes:
-      - .:/app:rw
-    env_file:
-      - .env
-    restart: unless-stopped
-  
+
+  news:
+    <<: *debug-common
+    image: echobot-debug
+    container_name: echobot-news-debug
+    command: ["python", "services/news_service/src/main.py"]
+    depends_on:
+      - event_notifier
+
+  music:
+    <<: *debug-common
+    image: echobot-debug
+    container_name: echobot-music-debug
+    command: ["python", "services/music_service/src/main.py"]
+    depends_on:
+      - event_notifier
+
+  obs:
+    <<: *debug-common
+    image: echobot-debug
+    container_name: echobot-obs-debug
+    command: ["python", "services/obs_stream_service/src/main.py"]
+    depends_on:
+      - api
+      - chat_youtube
+      - music
+      - news
+      - event_notifier

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,85 @@
+x-common-service: &common-service
+  env_file:
+    - .env
+  environment:
+    PYTHONPATH: /app
+    YOUTUBE_ENABLED: ${YOUTUBE_ENABLED:-false}
+    POLL_INTERVAL_SECONDS: ${POLL_INTERVAL_SECONDS:-30}
+  volumes:
+    - ./.env:/app/.env:ro
+    - ./logs:/app/logs:rw
+    - ./app/media:/app/media:rw
+  restart: unless-stopped
+
 services:
-  unified_container:
+  api:
+    <<: *common-service
     build:
       context: .
-      dockerfile: ./Dockerfile
-    image: unified_container
-    container_name: unified_container
-    command: ["tail", "-f", "/dev/null"]
+      dockerfile: ./services/api/Dockerfile
+      target: prod
+    image: echobot-api
+    container_name: echobot-api
+    command: ["python", "-m", "services.api.src.main", "--host", "0.0.0.0", "--port", "8000"]
     ports:
       - "8000:8000"
+
+  chat_youtube:
+    <<: *common-service
+    build:
+      context: .
+      dockerfile: ./services/chat_youtube_service/Dockerfile
+      target: prod
+    image: echobot-chat-youtube
+    container_name: echobot-chat-youtube
+    command: ["python", "-m", "services.chat_youtube_service.src.main", "--host", "0.0.0.0", "--port", "8001"]
+    ports:
       - "8001:8001"
+    depends_on:
+      - api
+
+  event_notifier:
+    <<: *common-service
+    build:
+      context: .
+      dockerfile: ./services/event_notifier_service/Dockerfile
+      target: prod
+    image: echobot-event-notifier
+    container_name: echobot-event-notifier
+    command: ["python", "-m", "services.event_notifier_service.src.main", "--host", "0.0.0.0", "--port", "8002"]
+    ports:
       - "8002:8002"
-      - "8003:8003"
-      - "8004:8004"
-    volumes:
-      - ./.env:/app/.env:ro
-      - ./logs:/app/logs:rw
-      - ./app/media:/app/app/media:rw
-    env_file:
-      - .env
-    restart: unless-stopped
+
+  news:
+    <<: *common-service
+    build:
+      context: .
+      dockerfile: ./services/news_service/Dockerfile
+    image: echobot-news
+    container_name: echobot-news
+    depends_on:
+      - event_notifier
+
+  music:
+    <<: *common-service
+    build:
+      context: .
+      dockerfile: ./services/music_service/Dockerfile
+    image: echobot-music
+    container_name: echobot-music
+    depends_on:
+      - event_notifier
+
+  obs:
+    <<: *common-service
+    build:
+      context: .
+      dockerfile: ./services/obs_stream_service/Dockerfile
+    image: echobot-obs
+    container_name: echobot-obs
+    depends_on:
+      - api
+      - chat_youtube
+      - music
+      - news
+      - event_notifier

--- a/services/api/Dockerfile
+++ b/services/api/Dockerfile
@@ -9,17 +9,6 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-FROM base AS dev
-
-COPY pyproject.toml uv.lock ./
-RUN uv sync --group dev --group debug
-
-COPY . .
-
-ENV PATH="/app/.venv/bin:$PATH"
-
-CMD ["tail", "-f", "/dev/null"]
-
 FROM base AS prod
 
 COPY pyproject.toml uv.lock ./
@@ -30,4 +19,4 @@ COPY . .
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH=/app
 
-CMD ["python", "-m", "services.chat_youtube_service.src.main", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "services.api.src.main", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/event_notifier_service/Dockerfile
+++ b/services/event_notifier_service/Dockerfile
@@ -9,17 +9,6 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-FROM base AS dev
-
-COPY pyproject.toml uv.lock ./
-RUN uv sync --group dev --group debug
-
-COPY . .
-
-ENV PATH="/app/.venv/bin:$PATH"
-
-CMD ["tail", "-f", "/dev/null"]
-
 FROM base AS prod
 
 COPY pyproject.toml uv.lock ./
@@ -30,4 +19,4 @@ COPY . .
 ENV PATH="/app/.venv/bin:$PATH"
 ENV PYTHONPATH=/app
 
-CMD ["python", "-m", "services.chat_youtube_service.src.main", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["python", "-m", "services.event_notifier_service.src.main", "--host", "0.0.0.0", "--port", "8002"]

--- a/services/music_service/media/media_service.py
+++ b/services/music_service/media/media_service.py
@@ -75,7 +75,10 @@ class MediaInitializationService:
             soundcloud_downloader.download_songs()
         except Exception as e:
             logger.error(f"Error loading songs from soundcloud: {e}")
-            sys.exit(1)
+            logger.warning(
+                "Continuing without SoundCloud songs. Configure SOUNDCLOUD_CLIENT_ID to enable this feature."
+            )
+            return
 
     def load_videos_from_googledrive(self):
         logger.info("Loading videos from googledrive")

--- a/services/news_service/src/main.py
+++ b/services/news_service/src/main.py
@@ -180,8 +180,9 @@ async def main(topic: str):
     )
 
     if successful_connections == 0:
-        logger.error("CRITICAL ERROR: No MCP servers could be initialized!")
-        sys.exit(1)
+        logger.warning(
+            "No MCP servers could be initialized. Continuing with LLM-only mode."
+        )
     else:
         logger.info(
             f"SUCCESS: Proceeding with {len(mcp_tools)} tools from {successful_connections} working servers"

--- a/services/obs_stream_service/core/ama_section.py
+++ b/services/obs_stream_service/core/ama_section.py
@@ -6,20 +6,15 @@ import re
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from app_logging.logger import logger
 from config.config import Settings
-from LLM.llm_utils import generate_llm_response_async, clean_for_voice
 from LLM import load_agent_personality, load_json
-    AMA_reply_prompt,
-)
-
+from LLM.llm_utils import clean_for_voice, generate_llm_response_async
+from services.obs_stream_service.core.ama_promts import AMA_reply_prompt
 from voice.generate import generate_voice
-from config.config import Settings
-import yaml
-from LLM.llm_init import initialize_llms
-import sys
 
-settings = Settings()
 settings = Settings()
 
 


### PR DESCRIPTION
## Summary
- dockerized all EchoBot microservices with dedicated service definitions
- added Dockerfiles for API and event_notifier services
- updated compose files for normal and debug runs
- fixed chat_youtube image/runtime setup
- fixed obs startup crash caused by ama_section import/indentation issue
- hardened startup behavior so optional integrations (OBS/SoundCloud/MCP) degrade gracefully instead of crashing

## Validation
- ran: `docker compose -f docker-compose.yml up -d --build`
- verified all services are stable in `docker compose -f docker-compose.yml ps`:
  - api
  - chat_youtube
  - event_notifier
  - music
  - news
  - obs

## Notes
- optional external credentials are still required for full feature behavior (OBS, SoundCloud, Google Drive, MCP/APIFY), but services now stay up without them

## Issue
- Closes #7

## Contributor Wallet
- SOL: `ENz8fU57pUb8uXzp4uPyjJBsnBN98wt3vBrp9UTnWLsT`