### PR TITLE
Update MEDIA_CONTAINER_DIR path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You also need to configure the paths for the unified media directory in your `.e
 ```env
 # .env
 MEDIA_HOST_DIR=/path/to/your/project/echobot/app/media
-MEDIA_CONTAINER_DIR=./app/media
+MEDIA_CONTAINER_DIR=/app/media
 ```
 
 ### 4. Configure OBS


### PR DESCRIPTION
Wrong value shown for MEDIA_CONTAINER_DIR

You explain:

MEDIA_CONTAINER_DIR should be left as /app/media.

MEDIA_CONTAINER_DIR=./app/media
❌ This contradicts your explanation

✅ Fix to:
MEDIA_CONTAINER_DIR=/app/media


sol wallet : Fp91HCa4waW9ezk29XT12Xf11f4n8CCGowpEAYaC6uXL