### PR TITLE
Minor fixes to README.md formatting and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ You also need to configure the paths for the unified media directory in your `.e
 ```env
 # .env
 MEDIA_HOST_DIR=/path/to/your/project/echobot/app/media
-MEDIA_CONTAINER_DIR=./app/media
+MEDIA_CONTAINER_DIR=/app/media
 ```
 
 ### 4. Configure OBS


### PR DESCRIPTION
Corrected MEDIA_CONTAINER_DIR path, removed invalid spaces in JSON examples, and fixed curl header spacing.

Sol address: 3qBXaE5HLzHsbMRPggDHSGJituUjDEeMXwhpj1VqEg6q